### PR TITLE
Changes to improve accessibility

### DIFF
--- a/lib/AgendaDayTemplate.js
+++ b/lib/AgendaDayTemplate.js
@@ -38,7 +38,7 @@ class AgendaDayTemplate {
         // TODO render time metadata. Hell, render all scema metadata, right?
         return `
           <tr class="ka-table-tr">
-          <td class="ka-table-th">${start}-${end}</td>
+          <th class="ka-table-th">${start}-${end}</th>
           ${!row? '' : row.map((cell) => !cell? '' : this.renderCell(cell)).join('')}
           </tr>
           `

--- a/lib/AgendaDayTemplate.js
+++ b/lib/AgendaDayTemplate.js
@@ -67,8 +67,8 @@ class AgendaDayTemplate {
         <a href="#${hash}" data-id="${id}" data-hash="${hash}" class="ka-talk-title">${title}</a>
       </p>
       ${!videoUrl && !slidesUrl? '' : `<p class="ka-links">
-        ${!slidesUrl? '' : `<a href="${slidesUrl}" target="_blank" class="icon-slideshare" title="Slides"></a>`}
-        ${!videoUrl? '' : `<a href="${videoUrl}" target="_blank" class="icon-youtube-play" title="Video"></a>`}
+        ${!slidesUrl? '' : `<a href="${slidesUrl}" target="_blank" class="icon-slideshare" title="Slides"><span class="sr-only">Slides in new window of "${title}"</span></a>`}
+        ${!videoUrl? '' : `<a href="${videoUrl}" target="_blank" class="icon-youtube-play" title="Video"><span class="sr-only">Video in new window of "${title}"</span></a>`}
       </p>`}
       <div class="ka-feedback-footer">${new TalkFeedback(arguments[0]).renderFeedback()}</div>
       <p class="ka-author-brief">${authors.map((a) => this.renderAuthor(a)).join(', ')}</p>

--- a/lib/TalkDetailsPopup.js
+++ b/lib/TalkDetailsPopup.js
@@ -14,8 +14,8 @@ class TalkDetailsPopup {
 
     const talk = this.talk;
     let links = !talk.videoUrl && !talk.slidesUrl? '' : `<div class="ka-links ka-right">
-      ${!talk.slidesUrl? '' : `<a href="${talk.slidesUrl}" target="_blank" class="icon-slideshare" title="Slides"></a>`}
-      ${!talk.videoUrl? '' : `<a href="${talk.videoUrl}" target="_blank" class="icon-youtube-play" title="Video"></a>`}
+      ${!talk.slidesUrl? '' : `<a href="${talk.slidesUrl}" target="_blank" class="icon-slideshare" title="Slides"><span class="sr-only">Slides in new window of "${talk.title}"</span></a>`}
+      ${!talk.videoUrl? '' : `<a href="${talk.videoUrl}" target="_blank" class="icon-youtube-play" title="Video"><span class="sr-only">Video in new window of "${talk.title}"</span></a>`}
     </div>`;
     const html = `
       <div class="ka-talk-details-window">

--- a/scss/agenda.scss
+++ b/scss/agenda.scss
@@ -66,3 +66,14 @@
 .icon-youtube-play:hover {
   color: $red-dark;
 }
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0,0,0,0);
+    border: 0;
+}


### PR DESCRIPTION
I´ve added some changes to improve the accessibility of the schedule:

- due to the relations of the rows and cols, it is neccesary to add another `th` element

![koliseo](https://cloud.githubusercontent.com/assets/997038/13232464/8ecc893c-d9af-11e5-9ffb-f15b7bff4c9e.png)

In the above image there is only one relation for the talk (marked in yellow) but really, a talk is related with the track (marked in green) and with the hour (missing).

- added "hidden" text for the slides and video links. If the user gets all links of the table (image below), those about the slides and / or videos are not very operable due to the lack of text. 

![koliseo2](https://cloud.githubusercontent.com/assets/997038/13232520/cfa7e29e-d9af-11e5-8fcd-835d69845fb7.png)

I could not test the changes (only check the new code in the Babel webpage) due to problems report in #1 
